### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,12 +6,12 @@
 # Datatypes (KEYWORD1)
 ########################################
 
-NECIRDecode                 KEYWORD1
+NECIRDecode	KEYWORD1
 
 ########################################
 # Methods and Functions (KEYWORD2)
 ########################################
 
-init                        KEYWORD2
-stateMachine                KEYWORD2
-getNext                     KEYWORD2
+init	KEYWORD2
+stateMachine	KEYWORD2
+getNext	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords